### PR TITLE
Add mutli-completion support to GPT Tagger

### DIFF
--- a/nxontology_ml/gpt_tagger/README.md
+++ b/nxontology_ml/gpt_tagger/README.md
@@ -19,6 +19,7 @@ config = TaskConfig(
     prompt_path=ROOT_DIR / "prompts/precision_v1.txt",
     openai_model_name="gpt-4",
     node_attributes=["efo_id", "efo_label", "efo_definition"],
+    model_n=3,
 )
 
 # Get a few EFO nodes
@@ -28,7 +29,7 @@ nodes = (nxo.node_info(node) for node in sorted(nxo.graph)[:20])
 # Get their labels
 tagger = GptTagger.from_config(config)
 for ln in tagger.fetch_labels(nodes):
-    print(f"{ln.node_efo_id}: {ln.label}")
+    print(f"{ln.node_efo_id}: {ln.labels}")
 
 # Inspect metrics
 print("\nTagger metrics:")
@@ -36,31 +37,31 @@ pprint(tagger.get_metrics())
 ```
 You should get an output similar to:
 ```shell
-DOID:0050890: medium
-DOID:10113: low
-DOID:10718: low
-DOID:13406: medium
-DOID:1947: low
-DOID:7551: low
-EFO:0000094: high
-EFO:0000095: high
-EFO:0000096: medium
-EFO:0000174: medium
-EFO:0000178: medium
-EFO:0000180: medium
-EFO:0000181: medium
-EFO:0000182: medium
-EFO:0000183: medium
-EFO:0000186: medium
-EFO:0000191: medium
-EFO:0000195: low
-EFO:0000196: medium
-EFO:0000197: medium
+DOID:0050890: ['medium', 'medium', 'medium']
+DOID:10113: ['low', 'low', 'low']
+DOID:10718: ['low', 'low', 'low']
+DOID:13406: ['medium', 'medium', 'medium']
+DOID:1947: ['low', 'low', 'low']
+DOID:7551: ['low', 'low', 'low']
+EFO:0000094: ['high', 'high', 'high']
+EFO:0000095: ['high', 'high', 'high']
+EFO:0000096: ['medium', 'medium', 'medium']
+EFO:0000174: ['high', 'high', 'high']
+EFO:0000178: ['high', 'medium', 'medium']
+EFO:0000180: ['low', 'low', 'medium']
+EFO:0000181: ['high', 'medium', 'high']
+EFO:0000182: ['high', 'medium', 'high']
+EFO:0000183: ['high', 'medium', 'medium']
+EFO:0000186: ['high', 'high', 'high']
+EFO:0000191: ['high', 'high', 'high']
+EFO:0000195: ['low', 'medium', 'medium']
+EFO:0000196: ['high', 'high', 'high']
+EFO:0000197: ['high', 'medium', 'medium']
 
 Tagger metrics:
-Counter({'ChatCompletion/total_tokens': 3187,
+Counter({'ChatCompletion/total_tokens': 3543,
          'ChatCompletion/prompt_tokens': 3009,
-         'ChatCompletion/completion_tokens': 178,
+         'ChatCompletion/completion_tokens': 534,
          'Cache/get': 20,
          'Cache/misses': 20,
          'ChatCompletion/records_processed': 20,

--- a/nxontology_ml/gpt_tagger/_chat_completion_middleware.py
+++ b/nxontology_ml/gpt_tagger/_chat_completion_middleware.py
@@ -88,6 +88,8 @@ class _ChatCompletionMiddleware:
             partial_payload["temperature"] = config.model_temperature
         if config.model_top_p:
             partial_payload["top_p"] = config.model_top_p
+        if config.model_n:
+            partial_payload["n"] = config.model_n
         # At the moment, only chat_completion is supported.
         #  See: https://openai.com/blog/gpt-4-api-general-availability
         return cls(

--- a/nxontology_ml/gpt_tagger/_models.py
+++ b/nxontology_ml/gpt_tagger/_models.py
@@ -37,11 +37,14 @@ class TaskConfig:
     #   prompt content) but it's likely better to use manual cache invalidation
     prompt_version: str = "v1"
 
-    # See https://platform.openai.com/docs/api-reference/chat/create
+    # See https://platform.openai.com/docs/api-reference/chat/create#temperature
     model_temperature: float | None = None
 
-    # See https://platform.openai.com/docs/api-reference/chat/create
+    # See https://platform.openai.com/docs/api-reference/chat/create#top_p
     model_top_p: float | None = None
+
+    # See https://platform.openai.com/docs/api-reference/chat/create#n
+    model_n: int | None = None
 
     # Optionally hash cache key (string values for nodes)
     # The node features will be used as cache key if not hashed.
@@ -55,4 +58,5 @@ class LabelledNode:
     """
 
     node_efo_id: str
-    label: str
+    # If the model's `n` parameter is >1, then several completions are generated for each prompt
+    labels: list[str]

--- a/nxontology_ml/gpt_tagger/_openai_models.py
+++ b/nxontology_ml/gpt_tagger/_openai_models.py
@@ -22,6 +22,7 @@ class ChatCompletionsPayload(TypedDict):
     messages: list[ChatCompletionMessage]
     temperature: NotRequired[float]
     top_p: NotRequired[float]
+    n: NotRequired[int]
 
 
 class Choice(TypedDict):

--- a/nxontology_ml/gpt_tagger/tests/_integration_test.py
+++ b/nxontology_ml/gpt_tagger/tests/_integration_test.py
@@ -40,6 +40,7 @@ def test_readme_code_it() -> None:
         prompt_path=ROOT_DIR / "prompts/precision_v1.txt",
         openai_model_name="gpt-4",
         node_attributes=["efo_id", "efo_label", "efo_definition"],
+        model_n=3,
     )
 
     # Get a few EFO nodes
@@ -49,7 +50,7 @@ def test_readme_code_it() -> None:
     # Get their labels
     tagger = GptTagger.from_config(config)
     for ln in tagger.fetch_labels(nodes):
-        print(f"{ln.node_efo_id}: {ln.label}")
+        print(f"{ln.node_efo_id}: {ln.labels}")
 
     # Inspect metrics
     print("\nTagger metrics:")


### PR DESCRIPTION
Following a discussion with @ravwojdyla, he suggested checking how varied the outputs of GPT-4 get when generating several completions for a single prompt. This PR adds support for the [`n` parameter](https://platform.openai.com/docs/api-reference/chat/create#n) of openai's API.

Here is an example of output (from the updated readme):

---

```python
from pprint import pprint

from nxontology_ml.data import get_efo_otar_slim
from nxontology_ml.gpt_tagger import TaskConfig, GptTagger
from nxontology_ml.utils import ROOT_DIR

# Create a config for EFO nodes labelling
config = TaskConfig(
    name="precision",
    prompt_path=ROOT_DIR / "prompts/precision_v1.txt",
    openai_model_name="gpt-4",
    node_attributes=["efo_id", "efo_label", "efo_definition"],
    model_n=3,
)

# Get a few EFO nodes
nxo = get_efo_otar_slim()
nodes = (nxo.node_info(node) for node in sorted(nxo.graph)[:20])

# Get their labels
tagger = GptTagger.from_config(config)
for ln in tagger.fetch_labels(nodes):
    print(f"{ln.node_efo_id}: {ln.labels}")

# Inspect metrics
print("\nTagger metrics:")
pprint(tagger.get_metrics())
```
You should get an output similar to:
```shell
DOID:0050890: ['medium', 'medium', 'medium']
DOID:10113: ['low', 'low', 'low']
DOID:10718: ['low', 'low', 'low']
DOID:13406: ['medium', 'medium', 'medium']
DOID:1947: ['low', 'low', 'low']
DOID:7551: ['low', 'low', 'low']
EFO:0000094: ['high', 'high', 'high']
EFO:0000095: ['high', 'high', 'high']
EFO:0000096: ['medium', 'medium', 'medium']
EFO:0000174: ['high', 'high', 'high']
EFO:0000178: ['high', 'medium', 'medium']
EFO:0000180: ['low', 'low', 'medium']
EFO:0000181: ['high', 'medium', 'high']
EFO:0000182: ['high', 'medium', 'high']
EFO:0000183: ['high', 'medium', 'medium']
EFO:0000186: ['high', 'high', 'high']
EFO:0000191: ['high', 'high', 'high']
EFO:0000195: ['low', 'medium', 'medium']
EFO:0000196: ['high', 'high', 'high']
EFO:0000197: ['high', 'medium', 'medium']

Tagger metrics:
Counter({'ChatCompletion/total_tokens': 3543,
         'ChatCompletion/prompt_tokens': 3009,
         'ChatCompletion/completion_tokens': 534,
         'Cache/get': 20,
         'Cache/misses': 20,
         'ChatCompletion/records_processed': 20,
         'Cache/set': 20,
         'ChatCompletion/create_requests': 1})
```