### PR TITLE
Log requests and responses to/from OpenAI's API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,5 @@ Thumbs.db
 
 # Models
 catboost_info/
+
+logs/

--- a/experimentation/GPT-4_Experiments.ipynb
+++ b/experimentation/GPT-4_Experiments.ipynb
@@ -65,7 +65,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Fetching node tags using GPT-4: 100%|███████████████████████████| 500/500 [00:00<00:00, 4391.09it/s]"
+      "Fetching node tags using GPT-4: 100%|███████████████████████████| 500/500 [00:00<00:00, 4282.06it/s]"
      ]
     },
     {
@@ -430,7 +430,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Fetching node tags using GPT-4: 100%|███████████████████████████| 500/500 [00:00<00:00, 4609.48it/s]"
+      "Fetching node tags using GPT-4: 100%|███████████████████████████| 500/500 [00:00<00:00, 4572.51it/s]"
      ]
     },
     {
@@ -672,7 +672,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Fetching node tags using GPT-4: 100%|███████████████████████████| 500/500 [00:00<00:00, 3147.88it/s]"
+      "Fetching node tags using GPT-4: 100%|███████████████████████████| 500/500 [00:00<00:00, 4643.74it/s]"
      ]
     },
     {
@@ -777,7 +777,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "4495890a",
    "metadata": {
     "scrolled": true
@@ -787,7 +787,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Fetching node tags using GPT-4: 100%|███████████████████████████| 500/500 [00:00<00:00, 4751.46it/s]"
+      "Fetching node tags using GPT-4: 100%|███████████████████████████| 550/550 [00:00<00:00, 4525.22it/s]"
      ]
     },
     {
@@ -796,7 +796,7 @@
      "text": [
       "\n",
       "Tagger metrics:\n",
-      "Counter({'Cache/get': 500, 'Cache/hits': 500})\n"
+      "Counter({'Cache/get': 550, 'Cache/hits': 550})\n"
      ]
     },
     {
@@ -819,11 +819,6 @@
     "    allowed_labels=frozenset({\"low\", \"medium\", \"high\"}),\n",
     ")\n",
     "\n",
-    "# Get a few EFO nodes\n",
-    "X, y = read_training_data(take=N_SAMPLES, filter_out_non_disease=True)\n",
-    "nxo = get_efo_otar_slim()\n",
-    "nodes = [nxo.node_info(node) for node in X]\n",
-    "\n",
     "# Get their labels\n",
     "tagger = GptTagger.from_config(cot_config)\n",
     "labeled_nodes = []\n",
@@ -838,6 +833,14 @@
     "# Inspect metrics\n",
     "print(\"\\nTagger metrics:\")\n",
     "pprint(tagger.get_metrics())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dfc827d",
+   "metadata": {},
+   "source": [
+    "Example of [prompt](https://gist.github.com/yonromai/c637c1dabea0f66bae849acbb3a77053) and response choices ([#1](https://gist.github.com/yonromai/597dfce428c8fdd98350cc19abdbd79f), [#2](https://gist.github.com/yonromai/7ac91e6543df6d69ab9de264e481b75c))"
    ]
   },
   {

--- a/nxontology_ml/gpt_tagger/_models.py
+++ b/nxontology_ml/gpt_tagger/_models.py
@@ -1,6 +1,10 @@
 from dataclasses import dataclass
 from pathlib import Path
 
+from nxontology_ml.utils import ROOT_DIR
+
+LOG_DIR = ROOT_DIR / "logs/openai-api"
+
 
 @dataclass
 class TaskConfig:
@@ -62,6 +66,9 @@ class TaskConfig:
 
     # If present, only the text after the `end_of_cot_marker` will be parsed (useful for "chain of thoughts" prompts)
     end_of_cot_marker: str | None = None
+
+    # Optionally persist logs to disk
+    logs_path: Path | None = LOG_DIR
 
 
 @dataclass

--- a/nxontology_ml/gpt_tagger/_utils.py
+++ b/nxontology_ml/gpt_tagger/_utils.py
@@ -1,7 +1,11 @@
+import json
+import logging
 import sys
 from collections import Counter
 from collections.abc import Callable, Iterable
+from datetime import datetime
 from itertools import islice
+from pathlib import Path
 from typing import Any
 from urllib.parse import quote_plus
 
@@ -79,3 +83,15 @@ def counter_or_empty(counter: Counter[str] | None) -> Counter[str]:
     if counter is None:
         return Counter()
     return counter
+
+
+def log_json_if_enabled(
+    logs_path: Path | None,
+    dirname: str,
+    obj: Any,
+) -> None:
+    if logs_path:
+        file_path = logs_path / dirname / f"{datetime.utcnow().isoformat()}.json"
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        logging.debug(f"logging json to {file_path}")
+        file_path.write_text(json.dumps(obj, indent=2))

--- a/nxontology_ml/gpt_tagger/tests/_utils.py
+++ b/nxontology_ml/gpt_tagger/tests/_utils.py
@@ -19,6 +19,7 @@ precision_config = TaskConfig(
     openai_model_name="gpt-3.5-turbo",
     model_temperature=0,
     allowed_labels=frozenset({"low", "medium", "high"}),
+    logs_path=None,  # Don't log during tests (unless integration)
 )
 
 


### PR DESCRIPTION
This PR adds persistence on disk of all actual requests and responses to/from OpenAI's API by default.  (I don't know why I didn't implement this earlier - it's been bothering me for a while)

@ravwojdyla 

> it would be worth to take a look at the actual explanations from the current CoT prompts and look for patterns that we could improve, at least that worked well for me in the past. Otherwise we would be doing a "shotgun prompt tuning" ™️ ?

I fetched 50 more samples with the CoT prompt and used the new logging code to exact the [prompt](https://gist.github.com/yonromai/c637c1dabea0f66bae849acbb3a77053) and response choices ([#1](https://gist.github.com/yonromai/597dfce428c8fdd98350cc19abdbd79f), [#2](https://gist.github.com/yonromai/7ac91e6543df6d69ab9de264e481b75c))

Note: If you want the explanations for some specific nodes (e.g. based on worst errors), I can nuke the cache and rerun the tagging for all 500 nodes so we have the CoT explanation for all of them.

(cc: @eric-czech @dhimmel )