### PR TITLE
Ease NXOntology serialization

### DIFF
--- a/nxontology_ml/pickle_utils.py
+++ b/nxontology_ml/pickle_utils.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+import fsspec
+import networkx as nx
+from nxontology import NXOntology
+
+from nxontology_ml.data import EFO_OTAR_SLIM_URL, get_efo_otar_slim
+
+
+class HostedNXOntology(NXOntology[str]):
+    """
+    Ontology backed by a remotely hosted Json file (assumed immutable)
+    (Main purpose: Ease serialization of NXOntology)
+    """
+
+    def __init__(
+        self,
+        url: str,
+        graph: nx.DiGraph | None = None,
+    ):
+        super().__init__(graph=graph)
+        self._url = url
+
+    @classmethod
+    def from_url(cls, url: str = EFO_OTAR_SLIM_URL) -> "HostedNXOntology":
+        protocol = fsspec.get_fs_token_paths(url)[0].protocol
+        assert protocol.startswith("http"), f"Unsupported protocol: {protocol}"
+        return cls(url=url, graph=get_efo_otar_slim(url).graph)
+
+    ##
+    # Pickle logic
+    _CURRENT_PICKLE_VERSION = "v1"
+
+    def __getstate__(self) -> dict[str, Any]:
+        return {"version": self._CURRENT_PICKLE_VERSION, "_url": self._url}
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        assert state.get("version", None) == self._CURRENT_PICKLE_VERSION
+        self.__dict__.update(self.from_url(state["_url"]).__dict__)

--- a/nxontology_ml/tests/pickle_utils_test.py
+++ b/nxontology_ml/tests/pickle_utils_test.py
@@ -1,0 +1,12 @@
+import pickle
+
+from nxontology_ml.data import EFO_OTAR_SLIM_URL
+from nxontology_ml.pickle_utils import HostedNXOntology
+
+
+def test_nxo_graph_roundtrip() -> None:
+    nxo = HostedNXOntology.from_url(url=EFO_OTAR_SLIM_URL)
+    # To describe the pickled object to stdout, run:
+    # `pickletools.dis(pickle.dumps(nxo), annotate=1)`
+    nxo_roundtrip = pickle.loads(pickle.dumps(nxo))
+    assert set(nxo.graph) == set(nxo_roundtrip.graph)


### PR DESCRIPTION
**Context**: I'm currently working on serializing the trained model. Since the feature transformers have learnt state, they also need to be serialized, along with the actual model. I'm currently making sure that all objects whose references are held by feature transformers can be serialized reasonably well. This includes `NXOntology` (which reference is currently held by [`PrepareNodeFeatures`](https://github.com/related-sciences/nxontology-ml/blob/main/nxontology_ml/features.py#L48)).

@dhimmel I'd like your input on 2 aspects:
1. Do we want to serialize the exact version of the ontology when we freeze the feature pipeline?
    * Cons:
       * Would make it hard to predict on a version of the ontology which is different than the one trained on   
    * Pros:
      * Some properties derived of the graph state need to end up serialized (e.g. PCA weights post "fitting")
      * More robust (e.g. avoid "schema" change issues across versions, training/predict data drift, ...)
      * The `node_info` call becomes part of the feature pipeline / coupled
2. If we do want to serialize the version of the ontology as part of the feature pipeline, are you cool with the approach below? (gist: Instead of saving the whole graph, assume the graph is backed by an immutable url and only save the url).


A quick note: The PR doesn't make use of `HostedNXOntology` yet, but the idea it to ultimately replace the usage of `NXOntology[str]` by `HostedNXOntology` wherever it's serialized.

cc: @ravwojdyla, in case you have opinions. 