### PR TITLE
Enhance and test feature/model determinism 

### DIFF
--- a/experimentation/export_model_predictions.py
+++ b/experimentation/export_model_predictions.py
@@ -13,7 +13,7 @@ from experimentation.model_utils import BiasedMaeMetric
 from nxontology_ml.data import get_efo_otar_slim, read_training_data
 from nxontology_ml.efo import NodeXrefFeatures
 from nxontology_ml.features import NodeInfoFeatures, PrepareNodeFeatures
-from nxontology_ml.model import CatBoostDataFormatter
+from nxontology_ml.model import MODEL_SEED, CatBoostDataFormatter
 from nxontology_ml.text_embeddings.text_embeddings_transformer import (
     TextEmbeddingsTransformer,
 )
@@ -99,6 +99,7 @@ def export_model_predictions(
         learning_rate=0.5,
         iterations=5000,
         metric_period=250,
+        random_seed=MODEL_SEED,
     )
     model.fit(
         X=Pool(

--- a/experimentation/model_runner.py
+++ b/experimentation/model_runner.py
@@ -14,7 +14,7 @@ from nxontology_ml.features import (
     TherapeuticAreaFeatures,
 )
 from nxontology_ml.gpt_tagger import GptTagFeatures
-from nxontology_ml.model import CatBoostDataFormatter
+from nxontology_ml.model import MODEL_SEED, CatBoostDataFormatter
 from nxontology_ml.text_embeddings.embeddings_model import AutoModelEmbeddings
 from nxontology_ml.text_embeddings.text_embeddings_transformer import (
     TextEmbeddingsTransformer,
@@ -167,6 +167,7 @@ def run_experiments(
                 iterations=5000,
                 use_best_model=True,
                 metric_period=250,
+                random_seed=MODEL_SEED,
                 # early_stopping_rounds=1000,
                 # task_type="GPU",
                 # l2_leaf_reg=.01,

--- a/nxontology_ml/model.py
+++ b/nxontology_ml/model.py
@@ -1,12 +1,11 @@
-from typing import Any
-
 import catboost
 import numpy as np
 import pandas as pd
-from catboost import CatBoostClassifier, FeaturesData, Pool
-from sklearn.base import ClassifierMixin
+from catboost import FeaturesData
 
 from nxontology_ml.sklearn_transformer import NodeFeatures, NoFitTransformer
+
+MODEL_SEED = 42
 
 
 class CatBoostDataFormatter(NoFitTransformer[pd.DataFrame, catboost.FeaturesData]):
@@ -19,33 +18,3 @@ class CatBoostDataFormatter(NoFitTransformer[pd.DataFrame, catboost.FeaturesData
             num_feature_names=list(X.num_features.columns),
             cat_feature_names=list(X.cat_features.columns),
         )
-
-
-class CatBoostModel(ClassifierMixin):  # type: ignore[misc]
-    def __init__(self, **kwargs: Any):
-        # See CatBoostClassifier doc: https://catboost.ai/en/docs/concepts/python-reference_catboostclassifier
-        self._model: CatBoostClassifier = CatBoostClassifier(**kwargs)
-
-    def fit(
-        self, X: FeaturesData, y: list[str] | None = None, **fit_params: Any
-    ) -> "CatBoostModel":
-        assert y is not None, "Training data is required"
-        self._model.fit(X=Pool(data=X, label=list(y)), **fit_params)
-        return self
-
-    def predict(
-        self,
-        X: FeaturesData,
-        **predict_params: str,
-    ) -> np.ndarray:
-        return self._model.predict(data=Pool(data=X), **predict_params)
-
-    def get_feature_importance(self, X: FeaturesData, **gfi_params: Any) -> Any:
-        return self._model.get_feature_importance(data=Pool(data=X), **gfi_params)
-
-    def predict_proba(self, X: FeaturesData, **predict_params: Any) -> Any:
-        return self._model.predict_proba(X, **predict_params)
-
-    @property
-    def model_impl(self) -> CatBoostClassifier:
-        return self._model

--- a/nxontology_ml/tests/model_test.py
+++ b/nxontology_ml/tests/model_test.py
@@ -1,10 +1,11 @@
 import numpy as np
+from catboost import CatBoostClassifier, Pool
 from sklearn.pipeline import Pipeline, make_pipeline
 
 from nxontology_ml.data import read_training_data
 from nxontology_ml.efo import NodeXrefFeatures
 from nxontology_ml.features import NodeInfoFeatures, PrepareNodeFeatures
-from nxontology_ml.model import CatBoostDataFormatter, CatBoostModel
+from nxontology_ml.model import MODEL_SEED, CatBoostDataFormatter
 
 
 def test_e2e_model() -> None:
@@ -14,7 +15,7 @@ def test_e2e_model() -> None:
         NodeXrefFeatures(),
         CatBoostDataFormatter(),
     )
-    model = CatBoostModel(iterations=10, silent=True, random_seed=42)
+    model = CatBoostClassifier(iterations=10, silent=True, random_seed=MODEL_SEED)
     pipeline: Pipeline = make_pipeline(
         features_pipeline,
         model,
@@ -27,10 +28,10 @@ def test_e2e_model() -> None:
     assert r.shape == (1, 1)
 
     X_t = features_pipeline.transform([X[N]])
-    fi = model.get_feature_importance(X=X_t)
+    fi = model.get_feature_importance(data=Pool(data=X_t))
     assert fi.shape == (26,)
 
     fp = model.predict_proba(X=X_t)
     assert np.allclose(fp, np.array([[0.25247175, 0.22380082, 0.36932641, 0.15440102]]))
 
-    assert model.model_impl.tree_count_ == 10
+    assert model.tree_count_ == 10

--- a/nxontology_ml/text_embeddings/tests/conftest.py
+++ b/nxontology_ml/text_embeddings/tests/conftest.py
@@ -1,14 +1,10 @@
 from pathlib import Path
 
-import numpy as np
 import pytest
 from nxontology import NXOntology
 
 from nxontology_ml.data import get_efo_otar_slim
 from nxontology_ml.tests.utils import get_test_resource_path
-
-# Set global random seed for test reproducibility
-np.random.seed(seed=42)
 
 
 @pytest.fixture

--- a/nxontology_ml/text_embeddings/tests/text_embeddings_transformer_test.py
+++ b/nxontology_ml/text_embeddings/tests/text_embeddings_transformer_test.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from nxontology import NXOntology
+from pandas._testing import assert_frame_equal
 from sklearn.pipeline import make_pipeline
 
 from nxontology_ml.data import read_training_data
@@ -26,6 +27,7 @@ def test_end_to_end(nxo: NXOntology[str], embeddings_test_cache: Path) -> None:
     pnf = PrepareNodeFeatures(nxo)
     X, y = read_training_data(nxo=nxo, take=10)
 
+    ##
     # Disabled testing
     tet = TextEmbeddingsTransformer.from_config(
         enabled=False, embedding_model=cached_ame
@@ -35,6 +37,7 @@ def test_end_to_end(nxo: NXOntology[str], embeddings_test_cache: Path) -> None:
     assert len(nf.cat_features) == 0
     assert len(nf.num_features) == 0
 
+    ##
     # Full embedding Testing
     tet = TextEmbeddingsTransformer.from_config(
         use_lda=False, embedding_model=cached_ame
@@ -43,7 +46,12 @@ def test_end_to_end(nxo: NXOntology[str], embeddings_test_cache: Path) -> None:
     assert isinstance(nf, NodeFeatures)
     assert len(nf.cat_features) == 0
     assert_frame_equal_to(nf.num_features, "text_embeddings_full.json")
+    # Determinism
+    nf2 = make_pipeline(pnf, tet).fit_transform(X, y)
+    assert isinstance(nf2, NodeFeatures)
+    assert_frame_equal(nf.num_features, nf2.num_features)
 
+    ##
     # LDA Testing
     tet = TextEmbeddingsTransformer.from_config(
         use_lda=True, embedding_model=cached_ame
@@ -52,7 +60,12 @@ def test_end_to_end(nxo: NXOntology[str], embeddings_test_cache: Path) -> None:
     assert isinstance(nf, NodeFeatures)
     assert len(nf.cat_features) == 0
     assert nf.num_features.shape == (10, 2)
+    # Determinism
+    nf2 = make_pipeline(pnf, tet).fit_transform(X, y)
+    assert isinstance(nf2, NodeFeatures)
+    assert_frame_equal(nf.num_features, nf2.num_features)
 
+    ##
     # PCA Testing
     tet = TextEmbeddingsTransformer.from_config(
         use_lda=False, pca_components=8, embedding_model=cached_ame
@@ -61,6 +74,10 @@ def test_end_to_end(nxo: NXOntology[str], embeddings_test_cache: Path) -> None:
     assert isinstance(nf, NodeFeatures)
     assert len(nf.cat_features) == 0
     assert nf.num_features.shape == (10, 8)
+    # Determinism
+    nf2 = make_pipeline(pnf, tet).fit_transform(X, y)
+    assert isinstance(nf2, NodeFeatures)
+    assert_frame_equal(nf.num_features, nf2.num_features)
 
     # Make sure no network calls were made
-    assert dict(cached_ame._counter) == {"AutoModelEmbeddings/CACHE_HIT": 50}
+    assert set(cached_ame._counter.keys()) == {"AutoModelEmbeddings/CACHE_HIT"}

--- a/nxontology_ml/text_embeddings/text_embeddings_transformer.py
+++ b/nxontology_ml/text_embeddings/text_embeddings_transformer.py
@@ -12,6 +12,9 @@ from nxontology_ml.text_embeddings.embeddings_model import (
     AutoModelEmbeddings,
 )
 
+# Set global random seed for  reproducibility
+np.random.seed(seed=42)
+
 
 class TextEmbeddingsTransformer(TransformerMixin):  # type: ignore[misc]
     """


### PR DESCRIPTION
This PR:
- Adds determinism testing for the text embedding features
- Sets random seeds more broadly

Note: As far as I know, the model and all features, except the ChatGPT based ones, are deterministic. I looked into making the ChatGPT features deterministic but from what I got from their [API doc](https://platform.openai.com/docs/api-reference/chat/create), it's not possible to set a random seed from the API (the only way to affect the randomness is to set model parameters like the temperature, but this also affects the behavior of the model).

cc @dhimmel 